### PR TITLE
Correcting submodule repo location to fix installer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = main
 [submodule "SimpleHTTPServerWithUpload"]
 	path = SimpleHTTPServerWithUpload
-	url = https://github.com/git/ahuacate/SimpleHTTPServerWithUpload
+	url = https://github.com/ahuacate/SimpleHTTPServerWithUpload
 	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = main
 [submodule "SimpleHTTPServerWithUpload"]
 	path = SimpleHTTPServerWithUpload
-	url = //192.168.1.10/git/ahuacate/SimpleHTTPServerWithUpload
+	url = https://github.com/git/ahuacate/SimpleHTTPServerWithUpload
 	branch = main


### PR DESCRIPTION
Seems the git modules is referencing a local repo and that's causing installation issues.  This patch updates the dependency to point back to github.

See #4 #5 #6